### PR TITLE
Fixed App Crash 

### DIFF
--- a/app/src/main/java/com/ayushunleashed/mitram/fragments/ConnectionsFragment.kt
+++ b/app/src/main/java/com/ayushunleashed/mitram/fragments/ConnectionsFragment.kt
@@ -177,6 +177,7 @@ class ConnectionsFragment : Fragment() {
     {
         myConnectionsList.clear()
         progressBar.visibility = View.VISIBLE
+        //binding.myRecyclerView.visibility = View.GONE
 
 
         GlobalScope.launch(Dispatchers.IO) {
@@ -189,7 +190,7 @@ class ConnectionsFragment : Fragment() {
                 if (connectionsArray != null) {
                     for (uid in connectionsArray) {
                         sharedViewModel.messagesHashMap[uid] = getLastMessage(uid);
-                        var user = db.collection("users").document(uid).get().await().toObject(UserModel::class.java)!!
+                        var user = db.collection("users").document(uid).get().await().toObject(UserModel::class.java)
                         user?.let { myConnectionsList.add(it) }
 
                         Log.d("GENERAL", "${user?.displayName} is added to array" );
@@ -204,6 +205,7 @@ class ConnectionsFragment : Fragment() {
             {
                 binding.tvUserCount.text = "( ${myConnectionsList.size} )"
                 progressBar.visibility = View.GONE
+                //binding.myRecyclerView.visibility = View.VISIBLE
                 binding.refreshLayout.isRefreshing = false
                 Log.d("GENERAL", "connectionsArray by users list" + myConnectionsList.toString());
 

--- a/app/src/main/java/com/ayushunleashed/mitram/fragments/LikesFragment.kt
+++ b/app/src/main/java/com/ayushunleashed/mitram/fragments/LikesFragment.kt
@@ -112,7 +112,7 @@ class LikesFragment : Fragment() {
 
                         var user:UserModel? = null
                         val job = launch {
-                            user = db.collection("users").document(uid).get().await().toObject(UserModel::class.java)!!
+                            user = db.collection("users").document(uid).get().await().toObject(UserModel::class.java)
                         }
 
                         job.join()


### PR DESCRIPTION
Connection and Likes Fragment if a uid doesn't exist and we get null in users
* Why this happen , because deleting account & document, doesn't delete that users uid from other arrays, so array may have a uid, but no such document may exist.
* App was crashing if you tried to reload and then swiped up